### PR TITLE
Minor bugfix

### DIFF
--- a/Code/Forms/ModelComparisonForm.cs
+++ b/Code/Forms/ModelComparisonForm.cs
@@ -72,6 +72,7 @@ namespace Cupscale.Forms
             cutoutMode = cropMode.SelectedIndex == 1;
             if (cutoutMode)
             {
+                IOUtils.ClearDir(Paths.previewPath);
                 PreviewUI.SaveCurrentCutout();
                 currentSourcePath = Path.Combine(Paths.previewPath, "preview.png");
             }


### PR DESCRIPTION
## A proposed simple bugfix
### The bug
There is a minor issue with the model comparison tool. If a user would refresh the preview, the cutout option in the comparison tool would spit out an exception stating that it is unable to move the file, this can be seen in Figure 1. The output also contains some *undesirable* effects, which can be seen in Figure 2.

#### Figure 1. An example of the window where the exception.
![Figure 1](https://user-images.githubusercontent.com/24940520/116914641-355dfd00-ac08-11eb-9672-f3867d9c4d7a.png)

#### Figure 2. An example of the output, the correct image can be seen on the left, the previous preview image can be seen on the right two images.
![Figure 2](https://user-images.githubusercontent.com/24940520/116916467-9555a300-ac0a-11eb-8682-caea31a728e2.png)


### The problem
After familiarizing myself with the source code, I eventually pinned down the problem. When the preview is refreshed, a file is created, with the path of `preview/preview.png.png`. When the model selector is used in cutout mode, a new image with the path of `preview/preview.png` is created.

Both of these images are fed to [ESRGAN](https://github.com/JoeyBallentine/ESRGAN). This will cause one of the images to be upscaled, and I presume that Cupscale will attempt to modify it, but that same image was already locked by ESRGAN as it began upscaling the other image in the input directory. This is only my judgement, and something else could be going on...

### Changes made
 * Added a line to remove files in the `preview/` directory if the user wants to use the model comparison tool in cutout mode.