### PR TITLE
Disable OpenCL for Magick.NET

### DIFF
--- a/Code/Main/Program.cs
+++ b/Code/Main/Program.cs
@@ -67,6 +67,7 @@ namespace Cupscale
             AddBinsToPath();
             Implementations.Imps.Init();
             ResourceLimits.Memory = (ulong)Math.Round(ResourceLimits.Memory * 1.5f);
+            OpenCL.IsEnabled = false;
             Cleanup();
             Application.Run(new MainForm());
         }


### PR DESCRIPTION
This should fix a problem with Scaling with Magick.NET
That causes the program to crash https://github.com/dlemstra/Magick.NET/issues/317

1.39.0 crashes whenever I use the Scaling Features
1.38.0 didn't have this problem.

Alternatively this can also be solved by updating Magick.NET

Video Proof: https://youtu.be/xxjA_NRnBaE